### PR TITLE
Fix/version deduplicate message

### DIFF
--- a/src/cogs/version.py
+++ b/src/cogs/version.py
@@ -20,7 +20,7 @@ class Version(commands.Cog):
         release_extension = ""
         if eversion.RELEASE_CANDIDATE:
             release_extension = f"-rc{eversion.RELEASE_CANDIDATE}"
-        return f"Currently running e-bot version {eversion.MAJOR_VERSION}.{eversion.MINOR_VERSION}.{eversion.PATCH_VERSION}{release_extension}"
+        return f"{eversion.MAJOR_VERSION}.{eversion.MINOR_VERSION}.{eversion.PATCH_VERSION}{release_extension}"
 
 
 async def setup(bot):

--- a/src/eversion.py
+++ b/src/eversion.py
@@ -2,6 +2,6 @@
 
 MAJOR_VERSION = 0
 MINOR_VERSION = 1
-PATCH_VERSION = 0
+PATCH_VERSION = 1
 # Note - RC versions currently not in use - but may be in the future.
 RELEASE_CANDIDATE = None


### PR DESCRIPTION
### What?
Removes duplicate 'currently running' text from `Version._get_version_string()`
### Why?
So that the message for this command reads correctly